### PR TITLE
feat: display readme on directory change

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,6 +88,12 @@
         .then((cfg) => {
           if (cfg && typeof cfg.catMax === "number")
             window.CAT_MAX = cfg.catMax;
+          if (cfg && typeof cfg.readme === "string") {
+            window.INIT_README = cfg.readme;
+            window.dispatchEvent(
+              new CustomEvent("initreadme", { detail: cfg.readme })
+            );
+          }
         })
         .catch(() => {});
       // Start a download by programmatically clicking an <a>
@@ -102,6 +108,8 @@
         } catch {}
       };
     </script>
+
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 
     <!-- Datastar: Alpine-like data-* reactivity -->
     <script
@@ -136,11 +144,16 @@
           "DejaVu Sans Mono",
           monospace;
       }
+      .layout {
+        display: flex;
+        height: 100%;
+      }
       .terminal {
         height: 100%;
         padding: 1rem;
         outline: none;
         display: flex;
+        flex: 2;
       }
       .screen {
         margin: 0;
@@ -151,6 +164,12 @@
         text-shadow:
           0 0 2px var(--olivetti),
           0 0 4px var(--olivetti);
+      }
+      .readme {
+        flex: 1;
+        padding: 1rem;
+        overflow: auto;
+        border-left: 1px solid #333;
       }
       .line {
         display: block;
@@ -197,13 +216,20 @@
       }
     </style>
   </head>
-  <body>
-    <div
-      class="terminal"
-      data-signals="{ ps1: 'guest@browser:~$ ', cwd: '~', current: '', buffer: '<div class=\'line out\'>Welcome to lsget!</div><div class=\'line out\'>Type one of the commands below to get started.</div><div class=\'line out\'></div><div class=\'line out\'>Available commands:</div><div class=\'line out\'>• pwd - print working directory</div><div class=\'line out\'>• ls [-l]|dir [-l] - list files</div><div class=\'line out\'>• cd DIR - change directory</div><div class=\'line out\'>• cat FILE - view a text file</div><div class=\'line out\'>• get|rget|download FILE - download a file</div><div class=\'line out\'></div><br/>', history: [], histIndex: 0 }"
-      data-on-load="el.querySelector('#ghost').focus()"
-      data-on-click="el.querySelector('#ghost').focus()"
-      data-on-keydown="
+    <body>
+      <div class="layout" data-signals="{ ps1: 'guest@browser:~$ ', cwd: '~', current: '', buffer: '<div class=\'line out\'>Welcome to lsget!</div><div class=\'line out\'>Type one of the commands below to get started.</div><div class=\'line out\'></div><div class=\'line out\'>Available commands:</div><div class=\'line out\'>• pwd - print working directory</div><div class=\'line out\'>• ls [-l]|dir [-l] - list files</div><div class=\'line out\'>• cd DIR - change directory</div><div class=\'line out\'>• cat FILE - view a text file</div><div class=\'line out\'>• get|rget|download FILE - download a file</div><div class=\'line out\'></div><br/>', history: [], histIndex: 0, readme: '' }">
+        <div
+          class="terminal"
+          data-on-load="
+            el.querySelector('#ghost').focus();
+            const init = window.INIT_README || '';
+            $readme = init ? marked.parse(init) : '';
+            window.addEventListener('initreadme', (e) => {
+              $readme = e.detail ? marked.parse(e.detail) : '';
+            });
+          "
+          data-on-click="el.querySelector('#ghost').focus()"
+          data-on-keydown="
          const k=evt.key;
          if (k==='Enter') {
            const cmd = $current;
@@ -219,18 +245,21 @@
              body: JSON.stringify({ input: cmd })
            })
            .then(r => r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)))
-           .then((res) => {
-             const { output, download, cwd } = res || {};
+             .then((res) => {
+               const { output, download, cwd } = res || {};
              if (typeof output === 'string' && output.length) {
               console.log(ansiToHtml(output));
                $buffer += `<div class='line out'>${ansiToHtml(output)}</div>`;
              }
              if (download) { startDownload(download); }
-             if (cwd !== undefined) {
-                $cwd = cwd;
-                $ps1 = `guest@browser:${cwd}$ `;
-             }
-             requestAnimationFrame(()=>{ sc.scrollTop = sc.scrollHeight; });
+               if (cwd !== undefined) {
+                  $cwd = cwd;
+                  $ps1 = `guest@browser:${cwd}$ `;
+               }
+               if (res && Object.prototype.hasOwnProperty.call(res, 'readme')) {
+                 $readme = res.readme ? marked.parse(res.readme) : '';
+               }
+               requestAnimationFrame(()=>{ sc.scrollTop = sc.scrollHeight; });
            })
            .catch(err => {
              $buffer += `<div class='line out'>error: ${escapeHTML(String(err))}</div>`;
@@ -309,7 +338,9 @@
         class="screen"
         data-ref-screen
         data-effect="el.innerHTML = $buffer + `<div class='line'><span class='ps1'>${$ps1}</span><span class='input'></span><span class='cursor'>█</span></div>`; el.querySelector('.input').textContent = $current;"
-      ></pre>
+        ></pre>
+      </div>
+      <div id="readme" class="readme" data-effect="el.innerHTML = $readme"></div>
     </div>
   </body>
 </html>

--- a/main.go
+++ b/main.go
@@ -112,6 +112,27 @@ func colorizeName(info os.FileInfo, name string) string {
 	return color + name + colorReset
 }
 
+// readReadme returns the raw contents of README.md if present in dir.
+func readReadme(dir string) string {
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+	for _, e := range ents {
+		if !e.Type().IsRegular() {
+			continue
+		}
+		if strings.EqualFold(e.Name(), "README.md") {
+			b, err := os.ReadFile(filepath.Join(dir, e.Name()))
+			if err != nil {
+				return ""
+			}
+			return string(b)
+		}
+	}
+	return ""
+}
+
 // ===== Embed a fallback index.html (used only if the file isn't on disk) =====
 
 //go:embed index.html
@@ -313,9 +334,10 @@ type execReq struct {
 }
 
 type execResp struct {
-	Output   string `json:"output"`
-	Download string `json:"download,omitempty"`
-	CWD      string `json:"cwd,omitempty"`
+	Output   string  `json:"output"`
+	Download string  `json:"download,omitempty"`
+	CWD      string  `json:"cwd,omitempty"`
+	Readme   *string `json:"readme,omitempty"`
 }
 
 type completeReq struct {
@@ -336,7 +358,8 @@ type completeResp struct {
 }
 
 type configResp struct {
-	CatMax int64 `json:"catMax"`
+	CatMax int64   `json:"catMax"`
+	Readme *string `json:"readme,omitempty"`
 }
 
 // ===== Handlers =====
@@ -356,7 +379,8 @@ func (s *server) handleIndex(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *server) handleConfig(w http.ResponseWriter, r *http.Request) {
-	_ = json.NewEncoder(w).Encode(configResp{CatMax: s.catMax})
+	readme := readReadme(s.rootAbs)
+	_ = json.NewEncoder(w).Encode(configResp{CatMax: s.catMax, Readme: &readme})
 }
 
 func (s *server) handleExec(w http.ResponseWriter, r *http.Request) {
@@ -463,7 +487,8 @@ func (s *server) handleExec(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		sess.cwd = newV
-		_ = json.NewEncoder(w).Encode(execResp{Output: "", CWD: sess.cwd})
+		readme := readReadme(newReal)
+		_ = json.NewEncoder(w).Encode(execResp{Output: "", CWD: sess.cwd, Readme: &readme})
 		return
 
 	case "cat":


### PR DESCRIPTION
## Summary
- render README.md using marked.js and show rendered HTML
- preserve README pane across commands until directory changes
- clear README pane when a directory lacks README.md

## Testing
- `go build -v ./...`
- `go mod tidy` *(fails: Get "https://proxy.golang.org/github.com/stretchr/testify/@v/v1.10.0.zip": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689d986f8e408327a5566229ee94a248