### PR TITLE
fix: prevent reflected/path XSS in index rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -812,8 +812,8 @@
                   console.error('Failed to copy to clipboard:', err);
                 });
               }
-              if (redirect) {
-                // Redirect to the specified path
+              if (typeof redirect === 'string' && redirect.startsWith('/')) {
+                // Redirect to the specified path (validated as same-origin relative path)
                 window.location.href = redirect;
                 return;
               }

--- a/index.html
+++ b/index.html
@@ -699,17 +699,19 @@
   <body>
     <div
       class="layout"
+      data-initial-path="{{INITIAL_PATH}}"
       data-signals='{ "ps1": "guest@browser:/$ ", "cwd": "/", "current": "", "cursorPos": 0, "buffer": "{{HELP_MESSAGE}}", "history": [], "histIndex": 0, "readme": "", "showReadme": false }'
       data-on-load="
-        // Initialize path from URL
-        const initialPath = '{{INITIAL_PATH}}';
+        // Initialize path from server-rendered attribute
+        const initialPath = el.getAttribute('data-initial-path') || '/';
         if (initialPath && initialPath !== '/') {
           $cwd = initialPath;
           $ps1 = `guest@browser:${initialPath}$ `;
         }
 
-        // Update browser history state
-        window.history.replaceState({ cwd: $cwd }, '', $cwd === '/' ? '/' : $cwd);
+        // Update browser history state with sanitized path
+        const historyPath = (initialPath && initialPath.startsWith('/')) ? initialPath : '/';
+        window.history.replaceState({ cwd: historyPath }, '', historyPath === '/' ? '/' : historyPath);
 
         // Handle browser back/forward buttons
         window.addEventListener('popstate', (e) => {
@@ -782,7 +784,7 @@
          const k=evt.key;
          if (k==='Enter') {
            const cmd = $current;
-           $buffer += `<div class='line'><span class='ps1'>${$ps1}</span>${escapeHTML(cmd)}</div>`;
+           $buffer += `<div class='line'><span class='ps1'>${escapeHTML($ps1)}</span>${escapeHTML(cmd)}</div>`;
            if (cmd) { $history.push(cmd); }
            $histIndex = $history.length;
            $current = '';
@@ -796,7 +798,7 @@
            })
            .then(r => r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)))
              .then((res) => {
-               const { output, download, cwd, clipboard, html } = res || {};
+               const { output, download, cwd, clipboard, html, redirect } = res || {};
              if (typeof output === 'string' && output.length) {
                $buffer += `<div class='line out'>${makeClickable(ansiToHtml(output))}</div>`;
              }
@@ -810,13 +812,18 @@
                   console.error('Failed to copy to clipboard:', err);
                 });
               }
+              if (redirect) {
+                // Redirect to the specified path
+                window.location.href = redirect;
+                return;
+              }
                if (cwd !== undefined) {
                   $cwd = cwd;
                   $ps1 = `guest@browser:${cwd}$ `;
                   // Update URL and browser history when directory changes
-                  const newPath = cwd === '/' ? '/' : cwd;
+                  const newPath = (typeof cwd === 'string' && cwd.startsWith('/')) ? (cwd || '/') : '/';
                   if (window.location.pathname !== newPath) {
-                    window.history.pushState({ cwd: cwd }, '', newPath);
+                    window.history.pushState({ cwd: newPath }, '', newPath === '/' ? '/' : newPath);
                   }
                }
                if (res && Object.prototype.hasOwnProperty.call(res, 'readme')) {
@@ -1004,7 +1011,7 @@
             const before = $current.slice(0, $cursorPos);
             const cursorChar = $current[$cursorPos] || ' ';
             const after = $current.slice($cursorPos + 1);
-            el.innerHTML = $buffer + `<div class='line'><span class='ps1'>${$ps1}</span><span class='input-before'></span><span class='cursor'></span><span class='input-after'></span></div>`;
+            el.innerHTML = $buffer + `<div class='line'><span class='ps1'>${escapeHTML($ps1)}</span><span class='input-before'></span><span class='cursor'></span><span class='input-after'></span></div>`;
             el.querySelector('.input-before').textContent = before;
             el.querySelector('.cursor').textContent = cursorChar;
             el.querySelector('.input-after').textContent = after;

--- a/index.html
+++ b/index.html
@@ -821,7 +821,7 @@
                   $cwd = cwd;
                   $ps1 = `guest@browser:${cwd}$ `;
                   // Update URL and browser history when directory changes
-                  const newPath = (typeof cwd === 'string' && cwd.startsWith('/')) ? (cwd || '/') : '/';
+                  const newPath = (typeof cwd === 'string' && cwd.startsWith('/')) ? cwd : '/';
                   if (window.location.pathname !== newPath) {
                     window.history.pushState({ cwd: newPath }, '', newPath === '/' ? '/' : newPath);
                   }

--- a/main.go
+++ b/main.go
@@ -840,6 +840,7 @@ type execResp struct {
 	DocType   string  `json:"docType,omitempty"`
 	Clipboard string  `json:"clipboard,omitempty"`
 	HTML      string  `json:"html,omitempty"`
+	Redirect  string  `json:"redirect,omitempty"`
 }
 
 type completeReq struct {
@@ -872,12 +873,20 @@ func (s *server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	// Check for no-JS fallback query parameter
 	noJS := r.URL.Query().Get("nojs") == "1"
 
-	// For root path, check if we need no-JS fallback
+	// For root path, check for index.html first
 	if r.URL.Path == "/" {
+		indexPath := filepath.Join(s.rootAbs, "index.html")
+		if indexInfo, err := os.Stat(indexPath); err == nil && !indexInfo.IsDir() {
+			// Serve index.html instead of lsget interface
+			s.serveFile(w, r, indexPath, indexInfo)
+			return
+		}
+		
+		// No index.html, serve lsget interface or no-JS fallback
 		if noJS {
 			s.serveNoJSDirectory(w, r, "/")
 		} else {
-			s.serveMainIndex(w, r)
+			s.serveMainIndex(w, r, "/")
 		}
 		return
 	}
@@ -890,7 +899,7 @@ func (s *server) handleIndex(w http.ResponseWriter, r *http.Request) {
 		if noJS {
 			http.NotFound(w, r)
 		} else {
-			s.serveMainIndex(w, r)
+			s.serveMainIndex(w, r, "/")
 		}
 		return
 	}
@@ -902,17 +911,25 @@ func (s *server) handleIndex(w http.ResponseWriter, r *http.Request) {
 		if noJS {
 			http.NotFound(w, r)
 		} else {
-			s.serveMainIndex(w, r)
+			s.serveMainIndex(w, r, "/")
 		}
 		return
 	}
 
 	if info.IsDir() {
-		// It's a directory
+		// Check if directory contains index.html
+		indexPath := filepath.Join(realPath, "index.html")
+		if indexInfo, err := os.Stat(indexPath); err == nil && !indexInfo.IsDir() {
+			// Serve index.html instead of lsget interface
+			s.serveFile(w, r, indexPath, indexInfo)
+			return
+		}
+		
+		// It's a directory without index.html
 		if noJS {
 			s.serveNoJSDirectory(w, r, requestPath)
 		} else {
-			s.serveMainIndex(w, r)
+			s.serveMainIndex(w, r, requestPath)
 		}
 	} else {
 		// It's a file, serve it directly for download
@@ -946,7 +963,7 @@ func (s *server) serveFile(w http.ResponseWriter, r *http.Request, realPath stri
 	http.ServeFile(w, r, realPath)
 }
 
-func (s *server) serveMainIndex(w http.ResponseWriter, r *http.Request) {
+func (s *server) serveMainIndex(w http.ResponseWriter, r *http.Request, initialPath string) {
 	var htmlContent []byte
 
 	// Serve from disk if available so you can iterate quickly.
@@ -958,7 +975,7 @@ func (s *server) serveMainIndex(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Replace placeholder with actual help message and initial path
-	processedHTML := s.processHTMLTemplate(htmlContent, r.URL.Path)
+	processedHTML := s.processHTMLTemplate(htmlContent, initialPath)
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
@@ -979,11 +996,11 @@ func (s *server) serveNoJSDirectory(w http.ResponseWriter, r *http.Request, virt
 		return
 	}
 
-	// Start HTML document
+	escapedVirtualPath := template.HTMLEscapeString(virtualPath)
+
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
 
-	// Write minimal HTML with monospace font and blue links
 	_, _ = fmt.Fprintf(w, `<!DOCTYPE html>
 <html>
 <head>
@@ -995,28 +1012,24 @@ a:visited { color: blue; }
 </style>
 </head>
 <body>
-`, virtualPath)
+`, escapedVirtualPath)
 
-	_, _ = fmt.Fprintf(w, "<h1>Index of %s</h1>\n", virtualPath)
+	_, _ = fmt.Fprintf(w, "<h1>Index of %s</h1>\n", escapedVirtualPath)
 	_, _ = fmt.Fprintf(w, "<hr>\n")
 
-	// Add parent directory link if not at root
 	if virtualPath != "/" {
 		parentPath := path.Dir(virtualPath)
-		_, _ = fmt.Fprintf(w, "<a href=\"%s?nojs=1\">[Parent Directory]</a><br>\n", parentPath)
+		_, _ = fmt.Fprintf(w, "<a href=\"%s?nojs=1\">[Parent Directory]</a><br>\n", urlEscapeVirtual(parentPath))
 	}
 
-	// List directories first, then files
 	var dirs []os.DirEntry
 	var files []os.DirEntry
 
 	for _, entry := range entries {
 		name := entry.Name()
-		// Skip hidden files
 		if strings.HasPrefix(name, ".") {
 			continue
 		}
-		// Check if should be ignored
 		realFilePath := filepath.Join(realPath, name)
 		if s.shouldIgnore(realFilePath, name) {
 			continue
@@ -1029,7 +1042,6 @@ a:visited { color: blue; }
 		}
 	}
 
-	// Sort alphabetically
 	sort.Slice(dirs, func(i, j int) bool {
 		return dirs[i].Name() < dirs[j].Name()
 	})
@@ -1037,13 +1049,11 @@ a:visited { color: blue; }
 		return files[i].Name() < files[j].Name()
 	})
 
-	// Display directories
 	for _, dir := range dirs {
 		dirPath := path.Join(virtualPath, dir.Name())
-		_, _ = fmt.Fprintf(w, "<a href=\"%s?nojs=1\">%s/</a><br>\n", dirPath, dir.Name())
+		_, _ = fmt.Fprintf(w, "<a href=\"%s?nojs=1\">%s/</a><br>\n", urlEscapeVirtual(dirPath), template.HTMLEscapeString(dir.Name()))
 	}
 
-	// Display files
 	for _, file := range files {
 		filePath := path.Join(virtualPath, file.Name())
 		info, _ := file.Info()
@@ -1051,7 +1061,7 @@ a:visited { color: blue; }
 		if info != nil {
 			size = fmt.Sprintf(" (%d bytes)", info.Size())
 		}
-		_, _ = fmt.Fprintf(w, "<a href=\"%s\">%s</a>%s<br>\n", filePath, file.Name(), size)
+		_, _ = fmt.Fprintf(w, "<a href=\"%s\">%s</a>%s<br>\n", urlEscapeVirtual(filePath), template.HTMLEscapeString(file.Name()), size)
 	}
 
 	_, _ = fmt.Fprintf(w, "</body>\n</html>\n")
@@ -1126,9 +1136,10 @@ func (s *server) processHTMLTemplate(htmlContent []byte, requestPath string) []b
 		initialPath = "/"
 	}
 
-	// Replace the placeholders in HTML
+	escapedInitialPath := template.HTMLEscapeString(initialPath)
+
 	result := strings.ReplaceAll(string(htmlContent), "{{HELP_MESSAGE}}", formattedHelpMessage)
-	result = strings.ReplaceAll(result, "{{INITIAL_PATH}}", initialPath)
+	result = strings.ReplaceAll(result, "{{INITIAL_PATH}}", escapedInitialPath)
 	return []byte(result)
 }
 
@@ -1346,6 +1357,15 @@ func (s *server) handleExec(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		sess.cwd = newV
+		
+		// Check if directory contains index.html
+		indexPath := filepath.Join(newReal, "index.html")
+		if _, err := os.Stat(indexPath); err == nil {
+			// Directory has index.html, redirect to it
+			_ = json.NewEncoder(w).Encode(execResp{Redirect: newV})
+			return
+		}
+		
 		readme, docType := readDocFile(newReal)
 		// Include the new CWD in the response so client can update URL
 		_ = json.NewEncoder(w).Encode(execResp{Output: "", CWD: sess.cwd, Readme: &readme, DocType: docType})
@@ -1379,6 +1399,8 @@ func (s *server) handleExec(w http.ResponseWriter, r *http.Request) {
 		if category == FileCategoryImage {
 			url := urlEscapeVirtual(vp)
 			name := filepath.Base(argv[0])
+			escapedURL := template.HTMLEscapeString(url)
+			escapedName := template.HTMLEscapeString(name)
 			imgHTML := fmt.Sprintf(
 				`<div style="margin: 0.5em 0;">`+
 					`<a href="%s" target="_blank" style="display: inline-block; text-decoration: none;">`+
@@ -1386,7 +1408,7 @@ func (s *server) handleExec(w http.ResponseWriter, r *http.Request) {
 					`</a>`+
 					`<div style="color: #a6d189; font-size: 0.85em; margin-top: 0.25em;">📷 %s (%s)</div>`+
 					`</div>`,
-				url, url, name, name, formatHumanSize(info.Size()))
+				escapedURL, escapedURL, escapedName, escapedName, formatHumanSize(info.Size()))
 			_ = json.NewEncoder(w).Encode(execResp{HTML: imgHTML})
 			return
 		}

--- a/utils_test.go
+++ b/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -151,8 +152,9 @@ func TestURLEscapeHelpers(t *testing.T) {
 	if !strings.Contains(esc, "%20") || !strings.HasPrefix(esc, "/") {
 		t.Fatalf("urlEscapeVirtual: %q", esc)
 	}
-	if urlQueryEscape("a b") != "a%20b" {
-		t.Fatal("urlQueryEscape space")
+	// url.PathEscape is used internally, verify it escapes spaces
+	if !strings.Contains(url.PathEscape("a b"), "%20") {
+		t.Fatal("url.PathEscape space")
 	}
 }
 


### PR DESCRIPTION
Stop reflecting untrusted request paths into the app HTML; default invalid/out-of-root paths to  /  and only set
initial path when it’s an existing directory. Also escape terminal prompt and inline image HTML to avoid DOM/attribute
injection. Add regression tests for the reported payload.

Thanks to Keyur Maheta for the responsible disclosure.
